### PR TITLE
feat: mailConfirm 이메일인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// 이메일
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '2.6.3'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/acorn/omakase/controller/UserController.java
+++ b/src/main/java/acorn/omakase/controller/UserController.java
@@ -2,14 +2,17 @@ package acorn.omakase.controller;
 
 import acorn.omakase.domain.User;
 import acorn.omakase.dto.userdto.*;
+import acorn.omakase.service.EmailService;
 import acorn.omakase.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.apache.ibatis.annotations.Delete;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import javax.mail.MessagingException;
+
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @RestController
@@ -33,12 +36,20 @@ public class UserController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    // 아이디 찾기
+     // 아이디 찾기
     @PostMapping("/find/id")
     public ResponseEntity findId(@RequestBody FindIdRequest findIdRequest){
-            String id = userService.findId(findIdRequest);
+        String id = userService.findId(findIdRequest);
 
-            return new ResponseEntity(id, HttpStatus.OK);
+        return new ResponseEntity(id, HttpStatus.OK);
+    }
+
+    // 비밀번호 찾기
+    @PostMapping("/find/pw")
+    public ResponseEntity findPw(@RequestBody FindPwRequest findPwRequest){
+        String pw = userService.findPw(findPwRequest);
+        System.out.println("암호 : " + pw);
+        return new ResponseEntity(pw, HttpStatus.OK);
     }
 
 
@@ -48,7 +59,6 @@ public class UserController {
 
         return new ResponseEntity(userId, HttpStatus.OK);
     }
-
 
     // 회원탈퇴
     @PostMapping("/delete")
@@ -63,6 +73,16 @@ public class UserController {
         userService.idValidate(idValidateRequest);
         System.out.println("아이디 사용 가능");
         return new ResponseEntity(HttpStatus.OK);
+    }
+
+    private final EmailService emailService;
+
+    // 이메일 인증
+    @PostMapping("/login/mailConfirm")
+    public String mailConfirm(@RequestBody EmailAuthRequestDto emailDto) throws MessagingException, UnsupportedEncodingException {
+
+        String authCode = emailService.sendEmail(emailDto.getEmail());
+        return authCode;
     }
 
 }

--- a/src/main/java/acorn/omakase/dto/userdto/EmailAuthRequestDto.java
+++ b/src/main/java/acorn/omakase/dto/userdto/EmailAuthRequestDto.java
@@ -1,0 +1,12 @@
+package acorn.omakase.dto.userdto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class EmailAuthRequestDto {
+
+    @NotEmpty(message = "이메일을 입력해주세요")
+    public String email;
+}

--- a/src/main/java/acorn/omakase/dto/userdto/FindPwRequest.java
+++ b/src/main/java/acorn/omakase/dto/userdto/FindPwRequest.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class FindIdRequest {
-    private String name;
+public class FindPwRequest {
+    private String loginId;
     private String email;
     private String code;
 }

--- a/src/main/java/acorn/omakase/repository/UserMapper.java
+++ b/src/main/java/acorn/omakase/repository/UserMapper.java
@@ -5,6 +5,7 @@ import acorn.omakase.domain.User;
 import acorn.omakase.dto.userdto.DeleteIdRequest;
 import acorn.omakase.dto.userdto.FindIdRequest;
 
+import acorn.omakase.dto.userdto.FindPwRequest;
 import acorn.omakase.dto.userdto.LoginRequest;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -19,13 +20,15 @@ public interface UserMapper {
     void signup(User user);
 
 
-    String findId(FindIdRequest findid);
+    String findId(FindIdRequest findId);
+
+    String findPw(FindPwRequest findPw);
 
     User login(LoginRequest loginRequest);
 
-
     // 회원 탈퇴
     int deleteId(Long userId);
+
     // 비밀번호 가져오기(회원탈퇴)
     String getPw(Long userId);
 

--- a/src/main/java/acorn/omakase/service/EmailService.java
+++ b/src/main/java/acorn/omakase/service/EmailService.java
@@ -1,0 +1,81 @@
+package acorn.omakase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender emailSender;
+    private final SpringTemplateEngine templateEngine;
+    private String authNum;
+
+    private final RedisUtil redisUtil;
+
+    // 랜덤 인증코드 생성
+    private void createCode(){
+        Random random = new Random();
+        StringBuffer key = new StringBuffer();
+
+        for(int i=0;i<8;i++) {
+            int index = random.nextInt(3);
+
+            switch (index) {
+                case 0 :
+                    key.append((char) ((int)random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) ((int)random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(9));
+                    break;
+            }
+        }
+        authNum = key.toString();
+    }
+
+    //메일 양식 작성
+    private MimeMessage createEmailForm(String email) throws MessagingException, UnsupportedEncodingException {
+
+        createCode(); //인증 코드 생성
+        String setFrom = "dj5668@naver.com"; //email-config에 설정한 자신의 이메일 주소(보내는 사람)
+        String toEmail = email; //받는 사람
+        String title = "CODEBOX 회원가입 인증 번호"; //제목
+
+        MimeMessage message = emailSender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, email); //보낼 이메일 설정
+        message.setSubject(title); //제목 설정
+        message.setFrom(setFrom); //보내는 이메일
+        message.setText(setContext(authNum), "utf-8", "html");
+
+        return message;
+    }
+
+    //실제 메일 전송
+    public String sendEmail(String toEmail) throws MessagingException, UnsupportedEncodingException {
+
+        //메일전송에 필요한 정보 설정
+        MimeMessage emailForm = createEmailForm(toEmail);
+        //실제 메일 전송
+        emailSender.send(emailForm);
+
+        redisUtil.setDataExpire(authNum, toEmail , 60*5L);
+        return authNum; //인증 코드 반환
+    }
+
+    //타임리프를 이용한 context 설정
+    private String setContext(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("mail", context); //mail.html
+    }
+}

--- a/src/main/java/acorn/omakase/service/RedisUtil.java
+++ b/src/main/java/acorn/omakase/service/RedisUtil.java
@@ -1,0 +1,34 @@
+package acorn.omakase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final StringRedisTemplate redisTemplate;
+
+    public String getData(String key){
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public void setData(String key, String value){
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, long duration){
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key){
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/acorn/omakase/service/UserService.java
+++ b/src/main/java/acorn/omakase/service/UserService.java
@@ -7,10 +7,16 @@ import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.spring5.SpringTemplateEngine;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
 import java.util.List;
+import java.util.Random;
 
 @Slf4j
 @Service
@@ -18,6 +24,7 @@ import java.util.List;
 @Transactional
 public class UserService {
 
+    private final RedisUtil redisUtil;
     private final UserMapper userMapper;
 
     public List<User> getUserList() {
@@ -32,32 +39,45 @@ public class UserService {
     }
 
     // 아이디 찾기
-    public String findId(FindIdRequest findIdRequest){
+    public String findId(FindIdRequest findIdRequest) {
 
+        String email = findIdRequest.getEmail();
+        String redisEmail = redisUtil.getData(findIdRequest.getCode());
+
+        if (!email.equals(redisEmail)){
+            throw new IllegalStateException("인증번호 불일치");
+        }
         String id = userMapper.findId(findIdRequest);
 
-        User findId = User.of(findIdRequest);
-       
-
-        if(id== null){
-            throw new IllegalStateException("찾는 아이디가 없습니다.");
-        }
-        log.info("test");
         return id;
+    }
+
+    // 비밀번호 찾기
+    public String findPw(FindPwRequest findPwRequest){
+        String email = findPwRequest.getEmail();
+        String redisEmail = redisUtil.getData(findPwRequest.getCode());
+
+        if(!email.equals(redisEmail)){
+            throw new IllegalStateException("인증번호 불일치");
+        }
+
+        String pw = userMapper.findPw(findPwRequest);
+
+        return pw;
     }
 
     public User login(LoginRequest loginRequest) throws Exception {
         User userId = userMapper.login(loginRequest);
 
-        if(userId==null){
-             throw new Exception("아이디/비밀번호가 일치하지 않습니다.");
+        if (userId == null) {
+            throw new Exception("아이디/비밀번호가 일치하지 않습니다.");
         }
         return userId;
     }
 
 
     // 회원 탈퇴
-    public void delete(DeleteIdRequest deleteIdRequest){
+    public void delete(DeleteIdRequest deleteIdRequest) {
         DeleteIdRequest deleteUser = deleteIdRequest;
 
         Long userId = deleteUser.getUserId();
@@ -67,25 +87,28 @@ public class UserService {
         String password1 = deleteIdRequest.getPassword1();
         // 두번째 입력
         String password2 = deleteIdRequest.getPassword2();
-        if(password1.equals(password2 )){
-            if(password1.equals(password)){
+        if (password1.equals(password2)) {
+            if (password1.equals(password)) {
                 userMapper.deleteId(userId);
-            }else {
+            } else {
                 throw new IllegalStateException("비밀번호가 회원 정보와 틀립니다.");
             }
-        }else{
-             throw new IllegalStateException("입력한 두 비밀번호가 일치하지 않습니다.");
+        } else {
+            throw new IllegalStateException("입력한 두 비밀번호가 일치하지 않습니다.");
         }
     }
 
     // 아이디 중복 확인
-    public void idValidate(IdValidateRequest idValidateRequest){
+    public void idValidate(IdValidateRequest idValidateRequest) {
         User idChk = User.of(idValidateRequest);
 
         int check = userMapper.idValidate(idChk);
 
-        if(check > 0){
+        if (check > 0) {
             throw new IllegalStateException("중복된 아이디 입니다.");
         }
     }
+
+
+
 }

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -13,11 +13,16 @@
         VALUES (#{loginId}, #{name}, #{password}, #{email}, #{region}, #{nickname})
     </insert>
 
-
-    <select id="findid" parameterType="acorn.omakase.domain.User" resultType="String">
+    <!--회원 아이디 찾기-->
+    <select id="findId" parameterType="acorn.omakase.dto.userdto.FindIdRequest" resultType="String">
         SELECT login_id FROM USER WHERE name=#{name} and email=#{email}
     </select>
-  
+
+    <!--회원 비밀번호 찾기-->
+    <select id="findPw" parameterType="acorn.omakase.dto.userdto.FindPwRequest" resultType="String">
+        SELECT password FROM USER WHERE login_id=#{loginId}
+    </select>
+
     <select id="login" parameterType="acorn.omakase.domain.User" resultType="acorn.omakase.domain.User">
         SELECT COUNT(*)
         FROM USER

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 알고리즘 관리 서비스 CODEBOX 입니다.</h1>
+    <br>
+    <p> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 회원가입 인증 코드 입니다. </h3>
+        <div style="font-size:130%" th:text="${code}"> </div>
+    </div>
+    <br/>
+</div>
+
+
+</body>
+</html>


### PR DESCRIPTION
이메일 인증 구현
아이디,비밀번호 찾기에 이메일인증 추가

application.yml
spring:
  datasource:
    username: root
    password: 1234

    mapper-locations: classpath:/mapper/**/*.xml
    jdbc-url: jdbc:mysql://localhost:3306/omakase?&serverTimezone=UTC&autoReconnect=true&allowMultiQueries=true&characterEncoding=UTF-8
    driver: com.mysql.cj.jdbc.Driver

  main:
    allow-circular-references: true

  mail:
    host: smtp.naver.com
    port: 465
    username:  # 네이버아이디
    password: # 네이버 비밀번호
    properties:
      mail:
        smtp:
          starttls:
            enable: true
            required: true
          auth: true
          connectiontimeout: 5000
          timeout: 5000
          writetimeout: 5000
          ssl:
            trust: smtp.naver.com
            enable: true

  redis:
    host: 127.0.0.1
    port: 6379

mybatis:
  configuration:
    map-underscore-to-camel-case: true
  config-location: classpath:/mybatis/mybatis-config.xml

pagehelper:
  #  helper-dialect: h2
  auto-dialect: true
  page-size-zero: false
  reasonable: true
  offset-as-page-num: false
  row-bounds-with-count: false
  auto-runtime-dialect: false
  close-conn: true
  default-count: true